### PR TITLE
CMake add presets for windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ cmake-build-release/
 *.exe
 *.out
 *.app
+
+# vcpkg
+/3rd/vcpkg/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "msvc-x64-static-debug",
+      "displayName": "MSVC Win64",
+      "description": "Default build using Visual Studio generator",
+      "generator": "Visual Studio 16 2019",
+      "binaryDir": "${sourceDir}/build/msvc-x64-static-debug",
+      "cacheVariables": {
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "USE_PANGOLIN_VIEWER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "CMAKE_CXX_FLAGS": {
+          "type": "STRING",
+          "value": "/bigobj /W4 /MT /source-charset:utf-8 /execution-charset:utf-8 /wd4251 /wd4244 /wd4305 /wd4267 /wd4127 /Zo /EHsc"
+        },
+        "BUILD_SHARED_LIBS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/Install/Debug"
+        },
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/3rd/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      },
+      "environment": {
+        "DBoW2_DIR": "${sourceDir}/../DBoW2/Install/Debug/lib/cmake/DBoW2"
+      }
+    },
+    {
+      "name": "msvc-x64-static-release",
+      "displayName": "MSVC Win64",
+      "description": "Default build using Visual Studio generator",
+      "generator": "Visual Studio 16 2019",
+      "binaryDir": "${sourceDir}/build/msvc-x64-static-release",
+      "cacheVariables": {
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "USE_PANGOLIN_VIEWER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "CMAKE_CXX_FLAGS": {
+          "type": "STRING",
+          "value": "/bigobj /W4 /MT /source-charset:utf-8 /execution-charset:utf-8 /wd4251 /wd4244 /wd4305 /wd4267 /wd4127 /O2 /EHsc"
+        },
+        "BUILD_SHARED_LIBS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/Install/Release"
+        },
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/3rd/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      },
+      "environment": {
+        "DBoW2_DIR": "${sourceDir}/../DBoW2/Install/Release/lib/cmake/DBoW2"
+      }
+    }
+  ]
+}

--- a/scripts/windows/Build.bat
+++ b/scripts/windows/Build.bat
@@ -1,0 +1,12 @@
+@echo off
+
+set openvslam_root="%~dp0\..\.."
+
+cd %openvslam_root%
+
+cd Build/msvc-x64-static-release
+cmake --build . --target install --config Release
+
+cd ..
+cd msvc-x64-static-debug
+cmake --build . --target install --config Debug 

--- a/scripts/windows/Setup.bat
+++ b/scripts/windows/Setup.bat
@@ -1,0 +1,65 @@
+@echo off
+
+set openvslam_root="%~dp0\..\.."
+
+
+echo =======================
+echo Setup VCPKG
+echo =======================
+
+cd %openvslam_root%
+
+cd 3rd
+
+if exist vcpkg goto dbow2
+
+git clone -b 2020.11-1 https://github.com/microsoft/vcpkg.git
+cd vcpkg
+call bootstrap-vcpkg.bat
+call vcpkg.exe install g2o suitesparse yaml-cpp eigen3 glog opencv --triplet x64-windows-static
+
+
+:dbow2
+
+echo =======================
+echo Setup DBOW2
+echo =======================
+
+cd %openvslam_root%
+cd ..
+
+if exist DBoW2 goto openvslam
+
+
+git clone https://github.com/OpenVSLAM-Community/DBoW2.git
+cd DBoW2
+
+
+mkdir Install/Debug
+mkdir Install/Release
+
+
+mkdir Build
+cd Build
+
+cmake .. -DCMAKE_TOOLCHAIN_FILE="../../openvslam/3rd/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="../Install/Debug"
+cmake --build . --target install --config Debug
+
+cmake .. -DCMAKE_TOOLCHAIN_FILE="../../openvslam/3rd/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="../Install/Release"
+cmake --build . --target install --config Release
+
+
+:openvslam
+
+echo =======================
+echo Setup OpenVSLAM
+echo =======================
+
+cd %openvslam_root%
+
+mkdir Build
+cd Build
+
+
+cmake -S .. --preset=msvc-x64-static-debug
+cmake -S .. --preset=msvc-x64-static-release

--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
         include_directories(${CXSPARSE_INCLUDE_DIRS})
     endif()
     # SuiteSparse for g2o
-    find_package(SuiteSparse)
+    find_package(SuiteSparse CONFIG)
     if(SUITESPARSE_FOUND)
         include_directories(${SUITESPARSE_INCLUDE_DIRS})
     endif()


### PR DESCRIPTION
+ Add build script
+ Added CONFIG flag to find_package SuiteSparse to find missing cs.h
+ Currently only static build is supported

Examples are disabled because Pangolin build fails with vcpkg

ref. #23