### PR TITLE
Build by colcon and catkin_make_isolated

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rd/FBoW"]
+	path = 3rd/FBoW
+	url = git@github.com:OpenVSLAM-Community/FBoW.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,12 +135,12 @@ set(INCLUDES_DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 # ----- Build selection -----
 
-set(USE_PANGOLIN_VIEWER ON CACHE BOOL "Enable Pangolin Viewer")
+set(USE_PANGOLIN_VIEWER OFF CACHE BOOL "Enable Pangolin Viewer")
 set(USE_SOCKET_PUBLISHER OFF CACHE BOOL "Enable Socket Publisher")
 
 add_subdirectory(src)
 
-set(BUILD_EXAMPLES ON CACHE BOOL "Build examples")
+set(BUILD_EXAMPLES OFF CACHE BOOL "Build examples")
 if(BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()

--- a/Dockerfile.desktop
+++ b/Dockerfile.desktop
@@ -208,12 +208,9 @@ RUN set -x && \
   mkdir -p build && \
   cd build && \
   cmake \
-    -DBUILD_WITH_MARCH_NATIVE=OFF \
     -DUSE_PANGOLIN_VIEWER=ON \
-    -DUSE_SOCKET_PUBLISHER=OFF \
+    -DBUILD_EXAMPLES=ON \
     -DUSE_STACK_TRACE_LOGGER=ON \
-    -DBOW_FRAMEWORK=DBoW2 \
-    -DBUILD_TESTS=OFF \
     .. && \
   make -j${NUM_THREADS} && \
   rm -rf CMakeCache.txt CMakeFiles Makefile cmake_install.cmake example src && \

--- a/Dockerfile.ros
+++ b/Dockerfile.ros
@@ -119,12 +119,7 @@ RUN set -x && \
   mkdir -p build && \
   cd build && \
   CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}/lib/cmake cmake \
-    -DBUILD_WITH_MARCH_NATIVE=OFF \
-    -DUSE_PANGOLIN_VIEWER=ON \
-    -DUSE_SOCKET_PUBLISHER=OFF \
     -DUSE_STACK_TRACE_LOGGER=ON \
-    -DBOW_FRAMEWORK=DBoW2 \
-    -DBUILD_TESTS=OFF \
     .. && \
   make -j${NUM_THREADS} && \
   rm -rf CMakeCache.txt CMakeFiles Makefile cmake_install.cmake example src && \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -124,12 +124,7 @@ RUN set -x && \
   mkdir -p build && \
   cd build && \
   CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}/lib/cmake cmake \
-    -DBUILD_WITH_MARCH_NATIVE=OFF \
-    -DUSE_PANGOLIN_VIEWER=ON \
-    -DUSE_SOCKET_PUBLISHER=OFF \
     -DUSE_STACK_TRACE_LOGGER=ON \
-    -DBOW_FRAMEWORK=DBoW2 \
-    -DBUILD_TESTS=OFF \
     .. && \
   make -j${NUM_THREADS} && \
   rm -rf CMakeCache.txt CMakeFiles Makefile cmake_install.cmake example src && \

--- a/Dockerfile.socket
+++ b/Dockerfile.socket
@@ -202,12 +202,8 @@ RUN set -x && \
   mkdir -p build && \
   cd build && \
   cmake \
-    -DBUILD_WITH_MARCH_NATIVE=OFF \
-    -DUSE_PANGOLIN_VIEWER=OFF \
     -DUSE_SOCKET_PUBLISHER=ON \
     -DUSE_STACK_TRACE_LOGGER=ON \
-    -DBOW_FRAMEWORK=DBoW2 \
-    -DBUILD_TESTS=OFF \
     .. && \
   make -j${NUM_THREADS} && \
   rm -rf CMakeCache.txt CMakeFiles Makefile cmake_install.cmake example src && \

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>openvslam</name>
+    <version>0.1.1</version>
+    <description>OpenVSLAM: A Versatile Visual SLAM Framework</description>
+
+    <author>Shinya Sumikura</author>
+    <author>Mikiya Shibuya</author>
+    <author>Ken Sakurada</author>
+    <maintainer email="world.applepie@gmail.com">ymd-stella</maintainer>
+
+    <license>2-clause BSD</license>
+    <url type="website">https://openvslam-community.readthedocs.io/</url>
+
+    <buildtool_depend>cmake</buildtool_depend>
+
+    <depend>eigen</depend>
+    <depend>libg2o</depend>
+    <depend>libgoogle-glog-dev</depend>
+    <depend>libopencv-dev</depend>
+
+    <export>
+        <build_type>cmake</build_type>
+    </export>
+</package>

--- a/ros/1/src/openvslam/CMakeLists.txt
+++ b/ros/1/src/openvslam/CMakeLists.txt
@@ -165,7 +165,7 @@ set(json_INCLUDE_DIR ${OpenVSLAM_ROOT}/3rd/json/include)
 include_directories(${json_INCLUDE_DIR})
 
 # pangolin viewer
-set(USE_PANGOLIN_VIEWER ON CACHE BOOL "Enable Pangolin Viewer")
+set(USE_PANGOLIN_VIEWER OFF CACHE BOOL "Enable Pangolin Viewer")
 if(USE_PANGOLIN_VIEWER)
     find_library(Pangolin_Viewer_LIB pangolin_viewer HINTS ${OpenVSLAM_LIB_DIR})
     find_package(Pangolin REQUIRED)
@@ -196,7 +196,7 @@ catkin_package(CATKIN_DEPENDS
 # BoW framework #
 #################
 
-set(BOW_FRAMEWORK "DBoW2" CACHE STRING "DBoW2 or FBoW")
+set(BOW_FRAMEWORK "FBoW" CACHE STRING "DBoW2 or FBoW")
 set_property(CACHE BOW_FRAMEWORK PROPERTY STRINGS "DBoW2" "FBoW")
 
 if(BOW_FRAMEWORK MATCHES "DBoW2")

--- a/ros/2/src/openvslam/CMakeLists.txt
+++ b/ros/2/src/openvslam/CMakeLists.txt
@@ -167,7 +167,7 @@ set(json_INCLUDE_DIR ${OpenVSLAM_ROOT}/3rd/json/include)
 include_directories(${json_INCLUDE_DIR})
 
 # pangolin viewer
-set(USE_PANGOLIN_VIEWER ON CACHE BOOL "Enable Pangolin Viewer")
+set(USE_PANGOLIN_VIEWER OFF CACHE BOOL "Enable Pangolin Viewer")
 if(USE_PANGOLIN_VIEWER)
     find_library(Pangolin_Viewer_LIB pangolin_viewer HINTS ${OpenVSLAM_LIB_DIR})
     find_package(Pangolin REQUIRED)
@@ -190,7 +190,7 @@ endif()
 # BoW framework #
 #################
 
-set(BOW_FRAMEWORK "DBoW2" CACHE STRING "DBoW2 or FBoW")
+set(BOW_FRAMEWORK "FBoW" CACHE STRING "DBoW2 or FBoW")
 set_property(CACHE BOW_FRAMEWORK PROPERTY STRINGS "DBoW2" "FBoW")
 
 if(BOW_FRAMEWORK MATCHES "DBoW2")

--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -91,7 +91,7 @@ else()
 endif()
 
 # Check BoW Framework
-set(BOW_FRAMEWORK "DBoW2" CACHE STRING "DBoW2 or FBoW")
+set(BOW_FRAMEWORK "FBoW" CACHE STRING "DBoW2 or FBoW")
 set_property(CACHE BOW_FRAMEWORK PROPERTY STRINGS "DBoW2" "FBoW")
 if(BOW_FRAMEWORK MATCHES "DBoW2")
     find_package(DBoW2 REQUIRED)

--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -95,30 +95,27 @@ set(BOW_FRAMEWORK "FBoW" CACHE STRING "DBoW2 or FBoW")
 set_property(CACHE BOW_FRAMEWORK PROPERTY STRINGS "DBoW2" "FBoW")
 if(BOW_FRAMEWORK MATCHES "DBoW2")
     find_package(DBoW2 REQUIRED)
-    set(BoW_INCLUDE_DIR ${DBoW2_INCLUDE_DIRS})
+    set(BoW_INCLUDE_DIR ${DBoW2_INCLUDE_DIRS}})
     set(BoW_LIBRARY ${DBoW2_LIBS})
     target_compile_definitions(${PROJECT_NAME} PUBLIC USE_DBOW2)
+    message(STATUS "BoW framework: ${BOW_FRAMEWORK} (found in ${BoW_INCLUDE_DIR})")
 elseif(BOW_FRAMEWORK MATCHES "FBoW")
     find_package(fbow QUIET)
     if(fbow_FOUND)
-        set(BoW_INCLUDE_DIR_BUILD ${fbow_INCLUDE_DIRS})
-        set(BoW_INCLUDE_DIR_INSTALL ${fbow_INCLUDE_DIRS})
-        set(BoW_LIBRARY ${fbow_LIBS})
+        set(BoW_INCLUDE_DIR ${fbow_INCLUDE_DIRS}})
+        message(STATUS "BoW framework: ${BOW_FRAMEWORK} (found in ${BoW_INCLUDE_DIR})")
     else()
         add_subdirectory(${PROJECT_SOURCE_DIR}/3rd/FBoW ${PROJECT_BINARY_DIR}/3rd/FBoW)
-        include(${PROJECT_BINARY_DIR}/3rd/FBoW/fbowConfig.cmake)
-        set(BoW_INCLUDE_DIR_BUILD ${PROJECT_SOURCE_DIR}/3rd/FBoW/include)
-        set(BoW_INCLUDE_DIR_INSTALL 3rd/FBoW/include)
-        set(BoW_LIBRARY ${fbow_LIBS})
-        target_link_directories(${PROJECT_NAME}
-                                PUBLIC
-                                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/3rd/FBoW/src>
-                                $<INSTALL_INTERFACE:3rd/FBoW/src>)
+        target_include_directories(${PROJECT_NAME}
+                                   PUBLIC
+                                   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/FBoW/include>
+                                   $<INSTALL_INTERFACE:3rd/FBoW/include>)
+        message(STATUS "BoW framework: ${BOW_FRAMEWORK} (Using submodule)")
     endif()
+    set(BoW_LIBRARY ${fbow_LIBS})
 else()
     message(FATAL_ERROR "Invalid BoW framework: ${BOW_FRAMEWORK}")
 endif()
-message(STATUS "BoW framework: ${BOW_FRAMEWORK} (found in ${BoW_INCLUDE_DIR_BUILD})")
 
 # ----- Configure OpenVSLAM library -----
 
@@ -127,11 +124,9 @@ target_include_directories(${PROJECT_NAME}
                            PUBLIC
                            $<BUILD_INTERFACE:${json_INCLUDE_DIR}>
                            $<BUILD_INTERFACE:${spdlog_INCLUDE_DIR}>
-                           $<BUILD_INTERFACE:${BoW_INCLUDE_DIR_BUILD}>
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/>
                            $<INSTALL_INTERFACE:include/openvslam/3rd/json/include>
                            $<INSTALL_INTERFACE:include/openvslam/3rd/spdlog/include>
-                           $<INSTALL_INTERFACE:${BoW_INCLUDE_DIR_INSTALL}>
                            $<INSTALL_INTERFACE:include/>)
 
 # Link to required libraries

--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -99,13 +99,26 @@ if(BOW_FRAMEWORK MATCHES "DBoW2")
     set(BoW_LIBRARY ${DBoW2_LIBS})
     target_compile_definitions(${PROJECT_NAME} PUBLIC USE_DBOW2)
 elseif(BOW_FRAMEWORK MATCHES "FBoW")
-    find_package(fbow REQUIRED)
-    set(BoW_INCLUDE_DIR ${fbow_INCLUDE_DIRS})
-    set(BoW_LIBRARY ${fbow_LIBS})
+    find_package(fbow QUIET)
+    if(fbow_FOUND)
+        set(BoW_INCLUDE_DIR_BUILD ${fbow_INCLUDE_DIRS})
+        set(BoW_INCLUDE_DIR_INSTALL ${fbow_INCLUDE_DIRS})
+        set(BoW_LIBRARY ${fbow_LIBS})
+    else()
+        add_subdirectory(${PROJECT_SOURCE_DIR}/3rd/FBoW ${PROJECT_BINARY_DIR}/3rd/FBoW)
+        include(${PROJECT_BINARY_DIR}/3rd/FBoW/fbowConfig.cmake)
+        set(BoW_INCLUDE_DIR_BUILD ${PROJECT_SOURCE_DIR}/3rd/FBoW/include)
+        set(BoW_INCLUDE_DIR_INSTALL 3rd/FBoW/include)
+        set(BoW_LIBRARY ${fbow_LIBS})
+        target_link_directories(${PROJECT_NAME}
+                                PUBLIC
+                                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/3rd/FBoW/src>
+                                $<INSTALL_INTERFACE:3rd/FBoW/src>)
+    endif()
 else()
     message(FATAL_ERROR "Invalid BoW framework: ${BOW_FRAMEWORK}")
 endif()
-message(STATUS "BoW framework: ${BOW_FRAMEWORK} (found in ${BoW_INCLUDE_DIR})")
+message(STATUS "BoW framework: ${BOW_FRAMEWORK} (found in ${BoW_INCLUDE_DIR_BUILD})")
 
 # ----- Configure OpenVSLAM library -----
 
@@ -114,11 +127,11 @@ target_include_directories(${PROJECT_NAME}
                            PUBLIC
                            $<BUILD_INTERFACE:${json_INCLUDE_DIR}>
                            $<BUILD_INTERFACE:${spdlog_INCLUDE_DIR}>
-                           $<BUILD_INTERFACE:${BoW_INCLUDE_DIR}>
+                           $<BUILD_INTERFACE:${BoW_INCLUDE_DIR_BUILD}>
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/>
                            $<INSTALL_INTERFACE:include/openvslam/3rd/json/include>
                            $<INSTALL_INTERFACE:include/openvslam/3rd/spdlog/include>
-                           $<INSTALL_INTERFACE:${BoW_INCLUDE_DIR}>
+                           $<INSTALL_INTERFACE:${BoW_INCLUDE_DIR_INSTALL}>
                            $<INSTALL_INTERFACE:include/>)
 
 # Link to required libraries

--- a/wercker.yml
+++ b/wercker.yml
@@ -42,13 +42,13 @@ build_with_gui:
       code: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=ON -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON -DUSE_PANGOLIN_VIEWER=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON ..
         make -j $(($(nproc) / 2))
     - script:
       name: cmake and make with socket publisher
       code: |
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON -DUSE_SOCKET_PUBLISHER=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON ..
         make -j $(($(nproc) / 2))
 
 build_without_gui:
@@ -64,7 +64,7 @@ build_without_gui:
       code: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
         make -j $(($(nproc) / 2))
     - script:
       name: unit test
@@ -103,7 +103,7 @@ build_without_gui_fbow:
       code: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=FBoW -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=FBoW -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
         make -j $(($(nproc) / 2))
     - script:
       name: unit test
@@ -142,7 +142,7 @@ build_tutorial:
       code: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_OPENMP=OFF ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_OPENMP=OFF ..
         make -j $(($(nproc) / 2))
     - script:
       name: download a dataset
@@ -179,14 +179,14 @@ build_ros:
       code: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
         make -j $(($(nproc) / 2))
         make install
     - script:
       name: build ros packages
       code: |
         cd ros/1
-        catkin_make -j$(($(nproc) / 2)) -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2
+        catkin_make -j$(($(nproc) / 2)) -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2
     - script:
       name: run run_slam
       code: |
@@ -221,14 +221,14 @@ build_ros2:
       code: |
         mkdir build
         cd build
-        CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}/lib/cmake cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
+        CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}/lib/cmake cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2 -DBUILD_TESTS=ON -DUSE_SSE_ORB=ON ..
         make -j $(($(nproc) / 2))
         make install
     - script:
       name: build ros2 packages
       code: |
         cd ros/2
-        (source /opt/ros/${ROS2_DISTRO}/setup.bash && colcon build --parallel-workers $(($(nproc) / 2)) --cmake-args -DBUILD_WITH_MARCH_NATIVE=OFF -DUSE_PANGOLIN_VIEWER=OFF -DUSE_SOCKET_PUBLISHER=OFF -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2)
+        (source /opt/ros/${ROS2_DISTRO}/setup.bash && colcon build --parallel-workers $(($(nproc) / 2)) --cmake-args -DUSE_STACK_TRACE_LOGGER=ON -DBOW_FRAMEWORK=DBoW2)
     - script:
       name: run run_slam
       code: |


### PR DESCRIPTION
I have confirmed that I can build with `colcon build` and `catkin_make_isolated`.
Since DBoW2 is licensed under BSD+notification, I used FBoW as a submodule.