### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -345,6 +345,7 @@ When building with support for PangolinViewer, please specify the following cmak
         -DUSE_STACK_TRACE_LOGGER=ON \
         -DBOW_FRAMEWORK=DBoW2 \
         -DBUILD_TESTS=ON \
+        -DBUILD_EXAMPLES=ON \
         ..
     make -j4
 
@@ -361,6 +362,7 @@ When building with support for SocketViewer, please specify the following cmake 
         -DUSE_STACK_TRACE_LOGGER=ON \
         -DBOW_FRAMEWORK=DBoW2 \
         -DBUILD_TESTS=ON \
+        -DBUILD_EXAMPLES=ON \
         ..
     make -j4
 


### PR DESCRIPTION
Add `-DBUILD_EXAMPLES=ON` cmake flag to build the examples for running openVSLAM without ROS.

This is to make the document consistent with the 

```
After building, check to see if it was successfully built by executing ./run_kitti_slam -h
```