### PR TITLE
Refactoring about is_monocular

### DIFF
--- a/src/openvslam/data/keyframe.cc
+++ b/src/openvslam/data/keyframe.cc
@@ -374,6 +374,10 @@ float keyframe::compute_median_depth(const bool abs) const {
     return depths.at((depths.size() - 1) / 2);
 }
 
+bool keyframe::depth_is_avaliable() const {
+    return camera_->setup_type_ != camera::setup_type_t::Monocular;
+}
+
 void keyframe::set_not_to_be_erased() {
     cannot_be_erased_ = true;
 }

--- a/src/openvslam/data/keyframe.h
+++ b/src/openvslam/data/keyframe.h
@@ -169,6 +169,11 @@ public:
      */
     float compute_median_depth(const bool abs = false) const;
 
+    /**
+     * Whether or not the camera setting is capable of obtaining depth information
+     */
+    bool depth_is_avaliable() const;
+
     //-----------------------------------------
     // flags
 

--- a/src/openvslam/mapping_module.cc
+++ b/src/openvslam/mapping_module.cc
@@ -16,9 +16,9 @@
 
 namespace openvslam {
 
-mapping_module::mapping_module(data::map_database* map_db, const bool is_monocular)
-    : local_map_cleaner_(new module::local_map_cleaner(is_monocular)), map_db_(map_db),
-      local_bundle_adjuster_(new optimize::local_bundle_adjuster()), is_monocular_(is_monocular) {
+mapping_module::mapping_module(data::map_database* map_db)
+    : local_map_cleaner_(new module::local_map_cleaner()), map_db_(map_db),
+      local_bundle_adjuster_(new optimize::local_bundle_adjuster()) {
     spdlog::debug("CONSTRUCT: mapping_module");
 }
 
@@ -141,7 +141,7 @@ void mapping_module::mapping_with_new_keyframe() {
     store_new_keyframe();
 
     // remove redundant landmarks
-    local_map_cleaner_->remove_redundant_landmarks(cur_keyfrm_->id_);
+    local_map_cleaner_->remove_redundant_landmarks(cur_keyfrm_->id_, cur_keyfrm_->depth_is_avaliable());
 
     // triangulate new landmarks between the current frame and each of the covisibilities
     create_new_landmarks();
@@ -204,7 +204,8 @@ void mapping_module::create_new_landmarks() {
     // get the covisibilities of `cur_keyfrm_`
     // in order to triangulate landmarks between `cur_keyfrm_` and each of the covisibilities
     constexpr unsigned int num_covisibilities = 10;
-    const auto cur_covisibilities = cur_keyfrm_->graph_node_->get_top_n_covisibilities(num_covisibilities * (is_monocular_ ? 2 : 1));
+    const unsigned int heuristic_ratio = cur_keyfrm_->depth_is_avaliable() ? 1 : 2;
+    const auto cur_covisibilities = cur_keyfrm_->graph_node_->get_top_n_covisibilities(num_covisibilities * heuristic_ratio);
 
     // lowe's_ratio will not be used
     match::robust robust_matcher(0.0, false);
@@ -227,14 +228,15 @@ void mapping_module::create_new_landmarks() {
         // compute the baseline between the current and neighbor keyframes
         const Vec3_t baseline_vec = ngh_cam_center - cur_cam_center;
         const auto baseline_dist = baseline_vec.norm();
-        if (is_monocular_) {
+        if (cur_keyfrm_->camera_->setup_type_ == camera::setup_type_t::Monocular) {
             // if the scene scale is much smaller than the baseline, abort the triangulation
             const float median_depth_in_ngh = ngh_keyfrm->compute_median_depth(true);
-            if (baseline_dist < 0.02 * median_depth_in_ngh) {
+            const float triangulate_thr_ratio = 0.02f;
+            if (baseline_dist < triangulate_thr_ratio * median_depth_in_ngh) {
                 continue;
             }
         }
-        else {
+        else if (cur_keyfrm_->camera_->setup_type_ == camera::setup_type_t::Stereo) {
             // for stereo setups, it needs longer baseline than the stereo baseline
             if (baseline_dist < ngh_keyfrm->camera_->true_baseline_) {
                 continue;
@@ -302,7 +304,8 @@ void mapping_module::triangulate_with_two_keyframes(data::keyframe* keyfrm_1, da
 
 void mapping_module::update_new_keyframe() {
     // get the targets to check landmark fusion
-    const auto fuse_tgt_keyfrms = get_second_order_covisibilities(is_monocular_ ? 20 : 10, 5);
+    const unsigned int num_covisibilities = cur_keyfrm_->depth_is_avaliable() ? 10 : 20;
+    const auto fuse_tgt_keyfrms = get_second_order_covisibilities(num_covisibilities, 5);
 
     // resolve the duplication of landmarks between the current keyframe and the targets
     fuse_landmark_duplication(fuse_tgt_keyfrms);

--- a/src/openvslam/mapping_module.h
+++ b/src/openvslam/mapping_module.h
@@ -26,7 +26,7 @@ class map_database;
 class mapping_module {
 public:
     //! Constructor
-    mapping_module(data::map_database* map_db, const bool is_monocular);
+    mapping_module(data::map_database* map_db);
 
     //! Destructor
     ~mapping_module();
@@ -213,9 +213,6 @@ private:
 
     //-----------------------------------------
     // others
-
-    //! flag which indicates the tracking camera is monocular or not
-    const bool is_monocular_;
 
     //! flag for keyframe acceptability
     std::atomic<bool> keyfrm_acceptability_{true};

--- a/src/openvslam/module/local_map_cleaner.cc
+++ b/src/openvslam/module/local_map_cleaner.cc
@@ -5,17 +5,16 @@
 namespace openvslam {
 namespace module {
 
-local_map_cleaner::local_map_cleaner(const bool is_monocular)
-    : is_monocular_(is_monocular) {}
+local_map_cleaner::local_map_cleaner() {}
 
 void local_map_cleaner::reset() {
     fresh_landmarks_.clear();
 }
 
-unsigned int local_map_cleaner::remove_redundant_landmarks(const unsigned int cur_keyfrm_id) {
+unsigned int local_map_cleaner::remove_redundant_landmarks(const unsigned int cur_keyfrm_id, const bool depth_is_avaliable) {
     constexpr float observed_ratio_thr = 0.3;
     constexpr unsigned int num_reliable_keyfrms = 2;
-    const unsigned int num_obs_thr = is_monocular_ ? 2 : 3;
+    const unsigned int num_obs_thr = depth_is_avaliable ? 3 : 2;
 
     // states of observed landmarks
     enum class lm_state_t { Valid,
@@ -126,7 +125,7 @@ void local_map_cleaner::count_redundant_observations(data::keyframe* keyfrm, uns
 
         // if depth is within the valid range, it won't be considered
         const auto depth = keyfrm->depths_.at(idx);
-        if (!is_monocular_ && (depth < 0.0 || keyfrm->depth_thr_ < depth)) {
+        if (keyfrm->depth_is_avaliable() && (depth < 0.0 || keyfrm->depth_thr_ < depth)) {
             continue;
         }
 

--- a/src/openvslam/module/local_map_cleaner.h
+++ b/src/openvslam/module/local_map_cleaner.h
@@ -17,7 +17,7 @@ public:
     /**
      * Constructor
      */
-    explicit local_map_cleaner(const bool is_monocular);
+    explicit local_map_cleaner();
 
     /**
      * Destructor
@@ -46,7 +46,7 @@ public:
     /**
      * Remove redundant landmarks
      */
-    unsigned int remove_redundant_landmarks(const unsigned int cur_keyfrm_id);
+    unsigned int remove_redundant_landmarks(const unsigned int cur_keyfrm_id, const bool depth_is_avaliable);
 
     /**
      * Remove redundant keyframes
@@ -61,9 +61,6 @@ public:
 private:
     //! origin keyframe ID
     unsigned int origin_keyfrm_id_ = 0;
-
-    //! flag which indicates the tracking camera is monocular or not
-    const bool is_monocular_;
 
     //! fresh landmarks to check their redundancy
     std::list<data::landmark*> fresh_landmarks_;

--- a/src/openvslam/system.cc
+++ b/src/openvslam/system.cc
@@ -82,7 +82,7 @@ system::system(const std::shared_ptr<config>& cfg, const std::string& vocab_file
     // tracking module
     tracker_ = new tracking_module(cfg_, this, map_db_, bow_vocab_, bow_db_);
     // mapping module
-    mapper_ = new mapping_module(map_db_, camera_->setup_type_ == camera::setup_type_t::Monocular);
+    mapper_ = new mapping_module(map_db_);
     // global optimization module
     global_optimizer_ = new global_optimization_module(map_db_, bow_db_, bow_vocab_, cfg_->yaml_node_, camera_->setup_type_ != camera::setup_type_t::Monocular);
 


### PR DESCRIPTION
Removed is_monocular, which is equivalent to the information obtained from the current keyframe.

Note that the process of create_new_landmarks when using a RGBD camera will change.
It may be necessary to add some kind of threshold.