### PR TITLE
Change pose_cw to pose_wc in update_pose

### DIFF
--- a/src/openvslam/system.cc
+++ b/src/openvslam/system.cc
@@ -286,13 +286,14 @@ std::shared_ptr<Mat44_t> system::feed_RGBD_frame(const cv::Mat& rgb_img, const c
     return cam_pose_wc;
 }
 
-bool system::update_pose(const Mat44_t& pose) {
-    bool status = tracker_->request_update_pose(pose);
+bool system::update_pose(const Mat44_t& cam_pose_wc) {
+    const Mat44_t cam_pose_cw = cam_pose_wc.inverse();
+    bool status = tracker_->request_update_pose(cam_pose_cw);
     if (status) {
         // Even if state will be lost, still update the pose in map_publisher_
         // to clearly show new camera position
-        map_publisher_->set_current_cam_pose(pose);
-        map_publisher_->set_current_cam_pose_wc(pose.inverse());
+        map_publisher_->set_current_cam_pose(cam_pose_cw);
+        map_publisher_->set_current_cam_pose_wc(cam_pose_wc);
     }
     return status;
 }

--- a/src/openvslam/system.h
+++ b/src/openvslam/system.h
@@ -118,7 +118,7 @@ public:
 
     //! Request to update the pose to a given one.
     //! Return failure in case if previous request was not finished.
-    bool update_pose(const Mat44_t& pose);
+    bool update_pose(const Mat44_t& cam_pose_wc);
 
     //-----------------------------------------
     // management for pause


### PR DESCRIPTION
As, `system::feed_monocular/stereo/RGBD_frame()` return inverted WC-pose, it is logically that `update_pose(pose)` should also take the `pose_wc` in the same coordinate system as other main API routines.