### PR TITLE
Merge bug Fixes

### DIFF
--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -115,8 +115,8 @@ elseif(BOW_FRAMEWORK MATCHES "FBoW")
     else()
         target_include_directories(${PROJECT_NAME}
                                 PUBLIC
-                                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/FBoW/include>
-                                $<INSTALL_INTERFACE:include/fbow>)
+                                "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd/FBoW/include>"
+                                "$<INSTALL_INTERFACE:include/fbow>")
         set(BoW_LIBRARY fbow)
         message(STATUS "BoW framework: ${BOW_FRAMEWORK} (Using submodule)")
     endif()
@@ -129,12 +129,12 @@ endif()
 # Include directories
 target_include_directories(${PROJECT_NAME}
                            PUBLIC
-                           $<BUILD_INTERFACE:${json_INCLUDE_DIR}>
-                           $<BUILD_INTERFACE:${spdlog_INCLUDE_DIR}>
-                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/>
-                           $<INSTALL_INTERFACE:include/openvslam/3rd/json/include>
-                           $<INSTALL_INTERFACE:include/openvslam/3rd/spdlog/include>
-                           $<INSTALL_INTERFACE:include/>)
+                           "$<BUILD_INTERFACE:${json_INCLUDE_DIR}>"
+                           "$<BUILD_INTERFACE:${spdlog_INCLUDE_DIR}>"
+                           "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/>"
+                           "$<INSTALL_INTERFACE:include/openvslam/3rd/json/include>"
+                           "$<INSTALL_INTERFACE:include/openvslam/3rd/spdlog/include>"
+                           "$<INSTALL_INTERFACE:include/>")
 
 # Link to required libraries
 target_link_libraries(${PROJECT_NAME}

--- a/src/openvslam/data/common.cc
+++ b/src/openvslam/data/common.cc
@@ -31,7 +31,7 @@ nlohmann::json convert_keypoints_to_json(const std::vector<cv::KeyPoint>& keypts
                                {"ang", keypts.at(idx).angle},
                                {"oct", static_cast<unsigned int>(keypts.at(idx).octave)}};
     }
-    return std::move(json_keypts);
+    return json_keypts;
 }
 
 std::vector<cv::KeyPoint> convert_json_to_keypoints(const nlohmann::json& json_keypts) {


### PR DESCRIPTION
Fixed the remaining task in #3 

1. Fix warning by removing redundant std::move() 
2. Added double quotes around BUILD_INTERFACE and INSTALL_INTERFACE