### PR TITLE
Fix fisheye rectification downcast

### DIFF
--- a/src/openvslam/util/stereo_rectifier.cc
+++ b/src/openvslam/util/stereo_rectifier.cc
@@ -14,8 +14,12 @@ stereo_rectifier::stereo_rectifier(const std::shared_ptr<openvslam::config>& cfg
 stereo_rectifier::stereo_rectifier(camera::base* camera, const YAML::Node& yaml_node)
     : model_type_(load_model_type(yaml_node)) {
     spdlog::debug("CONSTRUCT: util::stereo_rectifier");
-    assert(camera->setup_type_ == camera::setup_type_t::Stereo);
-    assert(camera->model_type_ == camera::model_type_t::Perspective);
+    if (camera->setup_type_ != camera::setup_type_t::Stereo) {
+        throw std::runtime_error("When stereo rectification is used, 'setup' must be set to 'stereo'");
+    }
+    if (camera->model_type_ != camera::model_type_t::Perspective) {
+        throw std::runtime_error("When stereo rectification is used, 'model' must be set to 'perspective'");
+    }
     // set image size
     const cv::Size img_size(camera->cols_, camera->rows_);
     // set camera matrices


### PR DESCRIPTION
This PR fixes a faulty downcast that happens when enabling stereo rectification on a fisheye pair of cameras.