### PR TITLE
refactor: fix loop copy

### DIFF
--- a/src/openvslam/data/graph_node.cc
+++ b/src/openvslam/data/graph_node.cc
@@ -279,7 +279,7 @@ void graph_node::recover_spanning_connections() {
         std::shared_ptr<keyframe> max_weight_parent = nullptr;
         std::shared_ptr<keyframe> max_weight_child = nullptr;
 
-        for (const auto spanning_child : spanning_children_) {
+        for (const auto& spanning_child : spanning_children_) {
             auto locked_spanning_child = spanning_child.lock();
             if (locked_spanning_child->will_be_erased()) {
                 continue;
@@ -290,7 +290,7 @@ void graph_node::recover_spanning_connections() {
             const auto intersection = extract_intersection(new_parent_candidates, child_covisibilities);
 
             // find the new parent (which has the maximum weight with the spanning child) from the intersection
-            for (const auto parent_candidate : intersection) {
+            for (const auto& parent_candidate : intersection) {
                 const auto weight = locked_spanning_child->graph_node_->get_weight(parent_candidate);
                 if (max_weight < weight) {
                     max_weight = weight;
@@ -316,7 +316,7 @@ void graph_node::recover_spanning_connections() {
     // if it should be fixed
     if (!spanning_children_.empty()) {
         // set my parent as the new parent
-        for (const auto spanning_child : spanning_children_) {
+        for (const auto& spanning_child : spanning_children_) {
             spanning_child.lock()->graph_node_->change_spanning_parent(spanning_parent_.lock());
         }
     }

--- a/src/openvslam/data/keyframe.cc
+++ b/src/openvslam/data/keyframe.cc
@@ -132,7 +132,7 @@ nlohmann::json keyframe::to_json() const {
     // extract loop edges
     const auto loop_edges = graph_node_->get_loop_edges();
     std::vector<int> loop_edge_ids;
-    for (const auto loop_edge : loop_edges) {
+    for (const auto& loop_edge : loop_edges) {
         loop_edge_ids.push_back(loop_edge->id_);
     }
 

--- a/src/openvslam/data/map_database.cc
+++ b/src/openvslam/data/map_database.cc
@@ -61,7 +61,7 @@ std::vector<std::shared_ptr<keyframe>> map_database::get_all_keyframes() const {
     std::lock_guard<std::mutex> lock(mtx_map_access_);
     std::vector<std::shared_ptr<keyframe>> keyframes;
     keyframes.reserve(keyframes_.size());
-    for (const auto id_keyframe : keyframes_) {
+    for (const auto& id_keyframe : keyframes_) {
         keyframes.push_back(id_keyframe.second);
     }
     return keyframes;
@@ -81,7 +81,7 @@ std::vector<std::shared_ptr<keyframe>> map_database::get_close_keyframes_2d(cons
     // Calculate angles and distances between given pose and all keyframes
     Mat33_t M = pose.block<3, 3>(0, 0);
     Vec3_t Mt = pose.block<3, 1>(0, 3);
-    for (const auto id_keyframe : keyframes_) {
+    for (const auto& id_keyframe : keyframes_) {
         Mat33_t N = id_keyframe.second->get_cam_pose().block<3, 3>(0, 0);
         Vec3_t Nt = id_keyframe.second->get_cam_pose().block<3, 1>(0, 3);
         // Angle between two cameras related to given pose and selected keyframe
@@ -109,7 +109,7 @@ std::vector<std::shared_ptr<keyframe>> map_database::get_close_keyframes(const M
     // Calculate angles and distances between given pose and all keyframes
     Mat33_t M = pose.block<3, 3>(0, 0);
     Vec3_t Mt = pose.block<3, 1>(0, 3);
-    for (const auto id_keyframe : keyframes_) {
+    for (const auto& id_keyframe : keyframes_) {
         Mat33_t N = id_keyframe.second->get_cam_pose().block<3, 3>(0, 0);
         Vec3_t Nt = id_keyframe.second->get_cam_pose().block<3, 1>(0, 3);
         // Angle between two cameras related to given pose and selected keyframe
@@ -133,7 +133,7 @@ std::vector<std::shared_ptr<landmark>> map_database::get_all_landmarks() const {
     std::lock_guard<std::mutex> lock(mtx_map_access_);
     std::vector<std::shared_ptr<landmark>> landmarks;
     landmarks.reserve(landmarks_.size());
-    for (const auto id_landmark : landmarks_) {
+    for (const auto& id_landmark : landmarks_) {
         landmarks.push_back(id_landmark.second);
     }
     return landmarks;
@@ -383,7 +383,7 @@ void map_database::to_json(nlohmann::json& json_keyfrms, nlohmann::json& json_la
     // Save each keyframe as json
     spdlog::info("encoding {} keyframes to store", keyframes_.size());
     std::map<std::string, nlohmann::json> keyfrms;
-    for (const auto id_keyfrm : keyframes_) {
+    for (const auto& id_keyfrm : keyframes_) {
         const auto id = id_keyfrm.first;
         const auto keyfrm = id_keyfrm.second;
         assert(keyfrm);
@@ -398,7 +398,7 @@ void map_database::to_json(nlohmann::json& json_keyfrms, nlohmann::json& json_la
     // Save each 3D point as json
     spdlog::info("encoding {} landmarks to store", landmarks_.size());
     std::map<std::string, nlohmann::json> landmarks;
-    for (const auto id_lm : landmarks_) {
+    for (const auto& id_lm : landmarks_) {
         const auto id = id_lm.first;
         const auto& lm = id_lm.second;
         assert(lm);

--- a/src/openvslam/global_optimization_module.cc
+++ b/src/openvslam/global_optimization_module.cc
@@ -231,7 +231,7 @@ void global_optimization_module::correct_loop() {
 module::keyframe_Sim3_pairs_t global_optimization_module::get_Sim3s_before_loop_correction(const std::vector<std::shared_ptr<data::keyframe>>& neighbors) const {
     module::keyframe_Sim3_pairs_t Sim3s_nw_before_loop_correction;
 
-    for (const auto neighbor : neighbors) {
+    for (const auto& neighbor : neighbors) {
         // camera pose of `neighbor` BEFORE loop correction
         const Mat44_t cam_pose_nw = neighbor->get_cam_pose();
         // create Sim3 from SE3
@@ -383,11 +383,11 @@ auto global_optimization_module::extract_new_connections(const std::vector<std::
         new_connections[covisibility] = covisibility->graph_node_->get_connected_keyframes();
 
         // remove covisibilities
-        for (const auto keyfrm_to_erase : covisibilities) {
+        for (const auto& keyfrm_to_erase : covisibilities) {
             new_connections.at(covisibility).erase(keyfrm_to_erase);
         }
         // remove nighbors before loop fusion
-        for (const auto keyfrm_to_erase : neighbors_before_update) {
+        for (const auto& keyfrm_to_erase : neighbors_before_update) {
             new_connections.at(covisibility).erase(keyfrm_to_erase);
         }
     }

--- a/src/openvslam/io/map_database_io.cc
+++ b/src/openvslam/io/map_database_io.cc
@@ -93,7 +93,7 @@ void map_database_io::load_message_pack(const std::string& path) {
     const auto json_landmarks = json.at("landmarks");
     map_db_->from_json(cam_db_, bow_vocab_, bow_db_, json_keyfrms, json_landmarks);
     const auto keyfrms = map_db_->get_all_keyframes();
-    for (const auto keyfrm : keyfrms) {
+    for (const auto& keyfrm : keyfrms) {
         bow_db_->add_keyframe(keyfrm);
     }
 }

--- a/src/openvslam/io/trajectory_io.cc
+++ b/src/openvslam/io/trajectory_io.cc
@@ -143,7 +143,7 @@ void trajectory_io::save_keyframe_trajectory(const std::string& path, const std:
     spdlog::info("dump keyframe trajectory in \"{}\" format from keyframe {} to keyframe {} ({} keyframes)",
                  format, (*keyfrms.begin())->id_, (*keyfrms.rbegin())->id_, keyfrms.size());
 
-    for (const auto keyfrm : keyfrms) {
+    for (const auto& keyfrm : keyfrms) {
         const Mat44_t cam_pose_wc = keyfrm->get_cam_pose_inv();
         const auto timestamp = keyfrm->timestamp_;
 

--- a/src/openvslam/mapping_module.cc
+++ b/src/openvslam/mapping_module.cc
@@ -349,7 +349,7 @@ std::unordered_set<std::shared_ptr<data::keyframe>> mapping_module::get_second_o
     std::unordered_set<std::shared_ptr<data::keyframe>> fuse_tgt_keyfrms;
     fuse_tgt_keyfrms.reserve(cur_covisibilities.size() * 2);
 
-    for (const auto first_order_covis : cur_covisibilities) {
+    for (const auto& first_order_covis : cur_covisibilities) {
         if (first_order_covis->will_be_erased()) {
             continue;
         }
@@ -363,7 +363,7 @@ std::unordered_set<std::shared_ptr<data::keyframe>> mapping_module::get_second_o
 
         // get the covisibilities of the covisibility of the current keyframe
         const auto ngh_covisibilities = first_order_covis->graph_node_->get_top_n_covisibilities(second_order_thr);
-        for (const auto second_order_covis : ngh_covisibilities) {
+        for (const auto& second_order_covis : ngh_covisibilities) {
             if (second_order_covis->will_be_erased()) {
                 continue;
             }
@@ -388,7 +388,7 @@ void mapping_module::fuse_landmark_duplication(const std::unordered_set<std::sha
         // - duplication of matches
         // then, add matches and solve duplication
         auto cur_landmarks = cur_keyfrm_->get_landmarks();
-        for (const auto fuse_tgt_keyfrm : fuse_tgt_keyfrms) {
+        for (const auto& fuse_tgt_keyfrm : fuse_tgt_keyfrms) {
             matcher.replace_duplication(fuse_tgt_keyfrm, cur_landmarks);
         }
     }
@@ -401,7 +401,7 @@ void mapping_module::fuse_landmark_duplication(const std::unordered_set<std::sha
         std::unordered_set<std::shared_ptr<data::landmark>> candidate_landmarks_to_fuse;
         candidate_landmarks_to_fuse.reserve(fuse_tgt_keyfrms.size() * cur_keyfrm_->num_keypts_);
 
-        for (const auto fuse_tgt_keyfrm : fuse_tgt_keyfrms) {
+        for (const auto& fuse_tgt_keyfrm : fuse_tgt_keyfrms) {
             const auto fuse_tgt_landmarks = fuse_tgt_keyfrm->get_landmarks();
 
             for (const auto& lm : fuse_tgt_landmarks) {

--- a/src/openvslam/module/local_map_cleaner.cc
+++ b/src/openvslam/module/local_map_cleaner.cc
@@ -77,7 +77,7 @@ unsigned int local_map_cleaner::remove_redundant_keyframes(const std::shared_ptr
     unsigned int num_removed = 0;
     // check redundancy for each of the covisibilities
     const auto cur_covisibilities = cur_keyfrm->graph_node_->get_covisibilities();
-    for (const auto covisibility : cur_covisibilities) {
+    for (const auto& covisibility : cur_covisibilities) {
         // cannot remove the origin
         if (covisibility->id_ == origin_keyfrm_id_) {
             continue;
@@ -145,7 +145,7 @@ void local_map_cleaner::count_redundant_observations(const std::shared_ptr<data:
         // the number of the keyframes that observe `lm` with the more reliable (closer) scale
         unsigned int num_better_obs = 0;
 
-        for (const auto obs : observations) {
+        for (const auto& obs : observations) {
             const auto ngh_keyfrm = obs.first.lock();
             if (*ngh_keyfrm == *keyfrm) {
                 continue;

--- a/src/openvslam/module/loop_detector.cc
+++ b/src/openvslam/module/loop_detector.cc
@@ -100,7 +100,7 @@ bool loop_detector::detect_loop_candidates() {
 
 bool loop_detector::validate_candidates() {
     // disallow the removal of the candidates
-    for (const auto candidate : loop_candidates_to_validate_) {
+    for (const auto& candidate : loop_candidates_to_validate_) {
         candidate->set_not_to_be_erased();
     }
 
@@ -112,7 +112,7 @@ bool loop_detector::validate_candidates() {
     Sim3_world_to_curr_ = util::converter::to_eigen_mat(g2o_Sim3_world_to_curr_);
 
     if (!candidate_is_found) {
-        for (const auto loop_candidate : loop_candidates_to_validate_) {
+        for (const auto& loop_candidate : loop_candidates_to_validate_) {
             loop_candidate->set_to_be_erased();
         }
         return false;
@@ -132,7 +132,7 @@ bool loop_detector::validate_candidates() {
     // acquire all of the landmarks observed in the covisibilities of the candidate
     // check the already inserted landmarks
     std::unordered_set<std::shared_ptr<data::landmark>> already_inserted;
-    for (const auto covisibility : cand_covisibilities) {
+    for (const auto& covisibility : cand_covisibilities) {
         const auto lms_in_covisibility = covisibility->get_landmarks();
         for (const auto& lm : lms_in_covisibility) {
             if (!lm) {
@@ -160,7 +160,7 @@ bool loop_detector::validate_candidates() {
 
     // count up the matches
     unsigned int num_final_matches = 0;
-    for (const auto curr_assoc_lm_in_cand : curr_match_lms_observed_in_cand_) {
+    for (const auto& curr_assoc_lm_in_cand : curr_match_lms_observed_in_cand_) {
         if (curr_assoc_lm_in_cand) {
             ++num_final_matches;
         }
@@ -170,7 +170,7 @@ bool loop_detector::validate_candidates() {
 
     if (num_final_matches_thr_ <= num_final_matches) {
         // allow the removal of the candidates except for the selected one
-        for (const auto loop_candidate : loop_candidates_to_validate_) {
+        for (const auto& loop_candidate : loop_candidates_to_validate_) {
             if (*loop_candidate == *selected_candidate_) {
                 continue;
             }
@@ -181,7 +181,7 @@ bool loop_detector::validate_candidates() {
     else {
         spdlog::debug("destruct loop candidate because enough matches not acquired (< {})", num_final_matches_thr_);
         // allow the removal of all of the candidates
-        for (const auto loop_candidate : loop_candidates_to_validate_) {
+        for (const auto& loop_candidate : loop_candidates_to_validate_) {
             loop_candidate->set_to_be_erased();
         }
         return false;
@@ -195,7 +195,7 @@ float loop_detector::compute_min_score_in_covisibilities(const std::shared_ptr<d
     // search the mininum score among covisibilities
     const auto covisibilities = keyfrm->graph_node_->get_covisibilities();
     const auto& bow_vec_1 = keyfrm->bow_vec_;
-    for (const auto covisibility : covisibilities) {
+    for (const auto& covisibility : covisibilities) {
         if (covisibility->will_be_erased()) {
             continue;
         }

--- a/src/openvslam/optimize/global_bundle_adjuster.cc
+++ b/src/openvslam/optimize/global_bundle_adjuster.cc
@@ -49,7 +49,7 @@ void global_bundle_adjuster::optimize(const unsigned int lead_keyfrm_id_in_globa
     internal::se3::shot_vertex_container keyfrm_vtx_container(vtx_id_offset, keyfrms.size());
 
     // Set the keyframes to the optimizer
-    for (const auto keyfrm : keyfrms) {
+    for (const auto& keyfrm : keyfrms) {
         if (!keyfrm) {
             continue;
         }

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -305,7 +305,7 @@ void tracking_module::track() {
 
         // pass all of the keyframes to the mapping module
         const auto keyfrms = map_db_->get_all_keyframes();
-        for (const auto keyfrm : keyfrms) {
+        for (const auto& keyfrm : keyfrms) {
             mapper_->queue_keyframe(keyfrm);
         }
 


### PR DESCRIPTION
Refactor some files appearing as a warning during clang compile, eg:
```
.../openvslam/src/openvslam/data/graph_node.cc:293:29: warning: loop variable 'parent_candidate' creates a copy from type 'const std::shared_ptr<openvslam::data::keyframe>' [-Wrange-loop-construct]
            for (const auto parent_candidate : intersection) {
                            ^
.../openvslam/src/openvslam/data/graph_node.cc:293:18: note: use reference type 'const std::shared_ptr<openvslam::data::keyframe> &' to prevent copying
            for (const auto parent_candidate : intersection) {
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```