### PR TITLE
chore: fix target_compile_options when USE_OPENMP=OFF

### DIFF
--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -76,9 +76,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 # ----- Compile configuration -----
 
 # OpenMP
-target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
 set(USE_OPENMP OFF CACHE BOOL "Use OpenMP")
 if(USE_OPENMP)
+    target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
     target_compile_definitions(${PROJECT_NAME} PUBLIC USE_OPENMP)
     message(STATUS "OpenMP: ENABLED")
 else()


### PR DESCRIPTION
Avoid clang warnings (see below) because `target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})` is called even if USE_OPENMP=OFF.
```
clang: warning: argument unused during compilation: '-Xclang -fopenmp' [-Wunused-command-line-argument]
```

(I have not found if there is a good reason why this target_compile_options has been put outside the condition historically)