### PR TITLE
Fix/revert black remove white

### DIFF
--- a/src/pangolin_viewer/color_scheme.cc
+++ b/src/pangolin_viewer/color_scheme.cc
@@ -6,10 +6,7 @@
 namespace pangolin_viewer {
 
 color_scheme::color_scheme(const std::string& color_set_str) {
-    if (stricmp(color_set_str, std::string("white"))) {
-        set_color_as_white();
-    }
-    else if (stricmp(color_set_str, std::string("black"))) {
+    if (stricmp(color_set_str, std::string("black"))) {
         set_color_as_black();
     }
     else if (stricmp(color_set_str, std::string("purple"))) {
@@ -18,16 +15,6 @@ color_scheme::color_scheme(const std::string& color_set_str) {
     else {
         throw std::runtime_error("undefined color scheme: " + color_set_str);
     }
-}
-
-void color_scheme::set_color_as_white() {
-    bg_ = {{1.0f, 1.0f, 1.0f, 1.0f}};
-    grid_ = {{0.7f, 0.7f, 0.7f}};
-    curr_cam_ = {{0.0f, 1.0f, 0.0f}};
-    kf_line_ = {{0.0f, 0.0f, 1.0f}};
-    graph_line_ = {{0.0f, 1.0f, 0.0f, 0.6f}};
-    lm_ = {{0.0f, 0.0f, 0.0f}};
-    local_lm_ = {{1.0f, 0.0f, 0.0f}};
 }
 
 void color_scheme::set_color_as_black() {

--- a/src/pangolin_viewer/color_scheme.cc
+++ b/src/pangolin_viewer/color_scheme.cc
@@ -9,6 +9,9 @@ color_scheme::color_scheme(const std::string& color_set_str) {
     if (stricmp(color_set_str, std::string("white"))) {
         set_color_as_white();
     }
+    else if (stricmp(color_set_str, std::string("black"))) {
+        set_color_as_black();
+    }
     else if (stricmp(color_set_str, std::string("purple"))) {
         set_color_as_purple();
     }
@@ -25,6 +28,16 @@ void color_scheme::set_color_as_white() {
     graph_line_ = {{0.0f, 1.0f, 0.0f, 0.6f}};
     lm_ = {{0.0f, 0.0f, 0.0f}};
     local_lm_ = {{1.0f, 0.0f, 0.0f}};
+}
+
+void color_scheme::set_color_as_black() {
+    bg_ = {{0.15f, 0.15f, 0.15f, 1.0f}};
+    grid_ = {{0.3f, 0.3f, 0.3f}};
+    curr_cam_ = {{0.7f, 0.7f, 1.0f}};
+    kf_line_ = {{0.0f, 1.0f, 0.0f}};
+    graph_line_ = {{0.7f, 0.7f, 1.0f, 0.4f}};
+    lm_ = {{0.9f, 0.9f, 0.9f}};
+    local_lm_ = {{1.0f, 0.1f, 0.1f}};
 }
 
 void color_scheme::set_color_as_purple() {

--- a/src/pangolin_viewer/color_scheme.h
+++ b/src/pangolin_viewer/color_scheme.h
@@ -31,6 +31,8 @@ public:
 private:
     void set_color_as_white();
 
+    void set_color_as_black();
+
     void set_color_as_purple();
 
     static bool stricmp(const std::string& str1, const std::string& str2);

--- a/src/pangolin_viewer/color_scheme.h
+++ b/src/pangolin_viewer/color_scheme.h
@@ -29,8 +29,6 @@ public:
     std::array<float, 3> local_lm_{};
 
 private:
-    void set_color_as_white();
-
     void set_color_as_black();
 
     void set_color_as_purple();

--- a/src/pangolin_viewer/viewer.cc
+++ b/src/pangolin_viewer/viewer.cc
@@ -27,7 +27,7 @@ viewer::viewer(const YAML::Node& yaml_node, openvslam::system* system,
       point_size_(yaml_node["point_size"].as<unsigned int>(2)),
       camera_size_(yaml_node["camera_size"].as<float>(0.15)),
       camera_line_width_(yaml_node["camera_line_width"].as<unsigned int>(2)),
-      cs_(yaml_node["color_scheme"].as<std::string>("white")),
+      cs_(yaml_node["color_scheme"].as<std::string>("black")),
       mapping_mode_(system->mapping_module_is_enabled()),
       loop_detection_mode_(system->loop_detector_is_enabled()) {}
 


### PR DESCRIPTION
Since it was pointed out that the GUI was similar to ORB_SLAM2, I mistakenly thought that the default color scheme `black` was similar, but the ORB_SLAM2 color scheme was rather similar to the non-default `white`. Therefore, I changed the default back to `black` and removed `white`.